### PR TITLE
fix OH1.scala compile

### DIFF
--- a/tilelink/src/utils/OH1.scala
+++ b/tilelink/src/utils/OH1.scala
@@ -6,6 +6,7 @@ package utils
 
 import chisel3._
 import chisel3.util.OHToUInt
+import chisel3.util.Cat
 
 /**
   * Utilities for one-hot-1s encoding.


### PR DESCRIPTION
OH1.scala fail to compile with command `mill tilelink.compile`, below is last some lines of log:

```
[info] compiling 12 Scala sources to /home/ycy/proj/hw/tilelink/out/tilelink/compile.dest/classes ...
[error] /home/ycy/proj/hw/tilelink/tilelink/src/utils/OH1.scala:20:33: not found: value Cat
[error]     ((x << 1).asUInt | 1.U) & (~Cat(0.U(1.W), x)).asUInt
[error]                                 ^
[error] one error found
1 targets failed
tilelink.compile Compilation failed             
```                   